### PR TITLE
clone driver to prevent sharing of statement

### DIFF
--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -35,10 +35,11 @@ func BulkInsert(db *gorm.DB, objects []interface{}, chunkSize int, excludeColumn
 func loadDriver(db *gorm.DB) (drivers.Driver, error) {
 	driver := (drivers.Driver)(new(drivers.Ansi))
 	if val, ok := db.Get("gorm:bulk_insert_driver"); ok {
-		driver, ok = val.(drivers.Driver)
-		if !ok {
+		var driverPrototype drivers.Driver
+		if driverPrototype, ok = val.(drivers.Driver); !ok {
 			return nil, errors.New("gorm:bulk_insert_driver needs to implement the gormbulk Driver interface")
 		}
+		driver = driverPrototype.Clone()
 	}
 	return driver, nil
 }

--- a/drivers/ansi.go
+++ b/drivers/ansi.go
@@ -14,6 +14,11 @@ type Ansi struct {
 	placeholders []string
 }
 
+func (d *Ansi) Clone() Driver {
+	clone := *d
+	return &clone
+}
+
 func (d *Ansi) Init(mainScope *gorm.Scope, dbColumns []string) error {
 	// NOOP
 	return nil

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -3,6 +3,7 @@ package drivers
 import "github.com/jinzhu/gorm"
 
 type Driver interface {
+	Clone() Driver
 	Init(mainScope *gorm.Scope, dbColumns []string) error
 	PrepareRow(mainScope *gorm.Scope, attrSize int, objAttrs map[string]interface{}, obj interface{}) error
 	Execute(mainScope *gorm.Scope, dbColumns []string) error

--- a/drivers/pq.go
+++ b/drivers/pq.go
@@ -13,9 +13,14 @@ type Pq struct {
 	stmt *sql.Stmt
 }
 
+func (d *Pq) Clone() Driver {
+	clone := *d
+	return &clone
+}
+
 func (d *Pq) Init(mainScope *gorm.Scope, dbColumns []string) error {
 	var err error
-	db := mainScope.DB().CommonDB()
+	db := mainScope.SQLDB()
 	d.stmt, err = db.Prepare(pq.CopyIn(mainScope.TableName(), dbColumns...))
 	return err
 }


### PR DESCRIPTION
This fixes two problems:

1) I was not using the correct transaction scoped version of the database from gorm
2) I was reusing the driver object that was being set globally. This meant that the prepared statement it contained was being reused (and overwritten and all sorts of other things) which was causing the DB hangs.